### PR TITLE
Add Python 3 shebang to Python scripts

### DIFF
--- a/files/MavenMetaDataFixer.py
+++ b/files/MavenMetaDataFixer.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from __future__ import print_function
 import sys
 import os

--- a/files/ScriptBase.py
+++ b/files/ScriptBase.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from __future__ import print_function
 import sys
 import os

--- a/files/ToolsUpdater.py
+++ b/files/ToolsUpdater.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from __future__ import print_function
 import sys
 import os


### PR DESCRIPTION
Unix systems have the ability to invoke a specific interpreter for a script, specified via a [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)). In the case of standalone Python scripts, [this can be used](https://stackoverflow.com/a/19305076) to make them executable like so:
```sh
./shuffleboard.py
```
The more significant advantage to doing so is that, if `wpilib/$YEAR/tools/` is added to the PATH, one can do:
```sh
shuffleboard.py
```
from anywhere. To my knowledge, without the shebang, this is not possible, because it will be wrongly interpreted as a Bash script, and Python can't be invoked with `shuffleboard.py` alone, if we aren't in `tools`. This PR adds a Python 3 shebang to all of the relevant scripts in this repo.