### PR TITLE
Add shebangs to tools Python scripts

### DIFF
--- a/files/MavenMetaDataFixer.py
+++ b/files/MavenMetaDataFixer.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from __future__ import print_function
 import sys
 import os

--- a/files/ScriptBase.py
+++ b/files/ScriptBase.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from __future__ import print_function
 import sys
 import os

--- a/files/ToolsUpdater.py
+++ b/files/ToolsUpdater.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from __future__ import print_function
 import sys
 import os


### PR DESCRIPTION
This lets Linux users run the scripts as "./OutlineViewer.py" instead
of just "python ./OutlineViewer.py".